### PR TITLE
fix: port over updates from ecr viewer implementation

### DIFF
--- a/sass/_uswds-theme.scss
+++ b/sass/_uswds-theme.scss
@@ -12,11 +12,27 @@ $ASSET_PREFIX: "";
     // Component
     $theme-hero-image: "../../../../dist/img/hero.jpg",
     $theme-accordion-button-background-color: "blue-cool-60",
+    $theme-summary-box-background-color: "primary-lighter",
+    $theme-summary-box-border-color: "primary-light",
 
     // Color
     $theme-link-color: "blue-cool-50",
     $theme-link-hover-color: "blue-cool-70",
     $theme-link-active-color: "blue-cool-80",
+
+    $theme-color-primary: "blue-cool-60",
+    $theme-color-primary-light: "blue-cool-20",
+    $theme-color-primary-lighter: "blue-cool-10",
+    $theme-color-primary-lightest: "blue-cool-5",
+    $theme-color-primary-dark: "blue-cool-70",
+    $theme-color-primary-darker: "blue-cool-80",
+  
+    $theme-color-secondary: "violet-warm-60",
+    $theme-color-secondary-light: #bf9dc3,
+    $theme-color-secondary-lighter: #dccfdd,
+    $theme-color-secondary-lightest: "violet-warm-5",
+    $theme-color-secondary-dark: "violet-warm-70",
+    $theme-color-secondary-darker: "violet-warm-80",
 
     $theme-color-success: "green-cool-40v",
     $theme-color-success-light: "green-cool-20v",

--- a/sass/_variables.scss
+++ b/sass/_variables.scss
@@ -30,8 +30,9 @@ $destructive-primary: #d54309; // primary error / info color
 $destructive-dark: #b51d09; // error hover
 $destructive-darker: #6f3331; // error active
 
-// non-opaque color meter read of rgb(from $blue-cool-50 r g b / 5%);
-$background: rgb(243 246 249);
+// non-opaque color meter read of rgb(from $blue-cool-50 r g b / 5%) then made as minimally 
+// light while maintaining 4.5:1 contrast ratio with the primary color as text on it;
+$background: #fcfcfd;
 $background-dark: $gray-200;
 $background-darker: $gray-300;
 $background-darkest: $gray-500;

--- a/sass/_variables.scss
+++ b/sass/_variables.scss
@@ -1,7 +1,7 @@
 // From https://github.com/CDCgov/dibbs-design-system/blob/main/sass/_variables.scss
 
 @use "uswds-theme" as *;
-@use "tokens" as *;
+@use "_tokens" as *;
 
 // Pulled from the Design System Figma
 // https://www.figma.com/design/GHKuvdgY2CbfBRZKmetZNB/--DIBBs-Design-System?node-id=0-1&t=Mg5hMzBQIji0cBdB-1

--- a/sass/_variables.scss
+++ b/sass/_variables.scss
@@ -1,5 +1,7 @@
+// From https://github.com/CDCgov/dibbs-design-system/blob/main/sass/_variables.scss
+
 @use "uswds-theme" as *;
-@use "_tokens" as *;
+@use "tokens" as *;
 
 // Pulled from the Design System Figma
 // https://www.figma.com/design/GHKuvdgY2CbfBRZKmetZNB/--DIBBs-Design-System?node-id=0-1&t=Mg5hMzBQIji0cBdB-1
@@ -9,7 +11,9 @@ $application-max-width: 45rem;
 $application-wide-max-width: 90rem;
 $application-content-margins: 13.75rem;
 $application-content-margins-wide: 10rem;
-$application-content-width-wide: calc($application-wide-max-width - 2 * $application-content-margins-wide);
+$application-content-width-wide: calc(
+  $application-wide-max-width - 2 * $application-content-margins-wide
+);
 
 $header-content-height: 3rem;
 $footer-content-height: 5rem;
@@ -22,22 +26,12 @@ $text-secondary: $gray-500;
 $text-inactive: $gray-20;
 $text-inactive-dark: $gray-600;
 
-$brand-primary: $blue-cool-50; // branded text color
-$brand-light: $blue-cool-20; // ??? is in the swatch
-$brand-lighter: $blue-cool-10; // tertiary link text color
-$brand-lightest: $blue-cool-5; // secondary button background
-$brand-dark: $blue-cool-70; // secondary button text
-$brand-darker: $blue-cool-80; // ??? is in the swatch
-
-$accent-primary: $violet-warm-60; // primary CTA / info color
-$accent-dark: $violet-warm-70; // CTA hover
-$accent-darker: $violet-warm-80; // CTA active
-
 $destructive-primary: #d54309; // primary error / info color
 $destructive-dark: #b51d09; // error hover
 $destructive-darker: #6f3331; // error active
 
-$background: $gray-100;
+// non-opaque color meter read of rgb(from $blue-cool-50 r g b / 5%);
+$background: rgb(243 246 249);
 $background-dark: $gray-200;
 $background-darker: $gray-300;
 $background-darkest: $gray-500;

--- a/sass/design_system.scss
+++ b/sass/design_system.scss
@@ -330,7 +330,7 @@ a:active {
   background-color: color("secondary");
   box-shadow:
     0 0 0 2px color("secondary"),
-    inset 0 0 0 2px #fff;
+    inset 0 0 0 2px white;
 }
 
 .usa-checkbox__label {

--- a/sass/design_system.scss
+++ b/sass/design_system.scss
@@ -1,4 +1,4 @@
-@use "_variables" as *;
+@use "variables" as *;
 @use "uswds-core" as *;
 @use "uswds-theme" as *;
 
@@ -259,7 +259,7 @@ a:active {
   background-color: white;
   border-radius: 0.25rem;
   border: 1px solid $border-dark;
-  color: $accent-dark;
+  color: color("secondary-dark");
   font-size: 1rem;
   font-weight: 700;
   line-height: 140%;
@@ -273,18 +273,18 @@ a:active {
 .usa-pagination__link:hover,
 .usa-pagination__link:focus,
 .usa-pagination__link:active {
-  color: $accent-darker;
+  color: color("secondary-darker");
 }
-.usa-pagination__button:hover,
-.usa-pagination__button:focus,
-.usa-pagination__button:active {
-  border: 1px solid $border;
-  background-color: $hover-neutral;
+.usa-pagination__page-no > .usa-pagination__button {
+  &:hover, &:focus, &:active {
+    border: 1px solid $border;
+    background-color: $hover-neutral;
+  }
 }
 
 .usa-pagination__button,
 .usa-pagination__link {
-  color: $accent-primary;
+  color: color("secondary");
   font-size: 1rem;
   font-weight: 700;
   line-height: 140%;

--- a/sass/design_system.scss
+++ b/sass/design_system.scss
@@ -23,89 +23,102 @@ body {
   min-height: 100%;
 }
 
-header,
-footer {
+.usa-header,
+.usa-footer {
   padding: 1rem 5rem;
   margin: 0;
-  background-color: $brand-darker;
+  background-color: color("primary-darker");
 }
 
-h1 {
+h1,
+.usa-prose > h1 {
   @include u-font("serif", 12);
 }
-h2 {
+h2,
+.usa-prose > h2 {
   @include u-font("sans", 11);
 }
-h3 {
+h3,
+.usa-prose h3 {
   @include u-font("sans", 8);
 }
-h4 {
+h4,
+.usa-prose > h4,
+h5,
+.usa-prose > h5 {
   @include u-font("sans", 5);
 }
 
 .main-body {
-  background-color: $background;
   display: flex;
   flex: 1 1 auto;
 }
 
 .usa-button {
-  background-color: $accent-primary;
-  box-shadow: inset 0 0 0 2px $accent-primary;
+  background-color: color("secondary");
+  box-shadow: inset 0 0 0 2px color("secondary");
 
-  &:hover,
-  &--outline:hover {
-    box-shadow: inset 0 0 0 2px $accent-dark;
-    background-color: $accent-dark !important;
+  &:hover {
+    box-shadow: inset 0 0 0 2px color("secondary-dark");
+    background-color: color("secondary-dark");
   }
 
-  &:active,
-  &--outline:active {
-    box-shadow: inset 0 0 0 2px $accent-darker;
-    background-color: $accent-darker !important;
+  &:active {
+    box-shadow: inset 0 0 0 2px color("secondary-darker");
+    background-color: color("secondary-darker");
+  }
+
+  &--outline {
+    background-color: transparent;
+    color: color("secondary");
+
+    &:hover {
+      background-color: transparent;
+      box-shadow: inset 0 0 0 2px color("secondary-dark");
+      color: color("secondary-dark");
+    }
+
+    &:active {
+      background-color: transparent;
+      box-shadow: inset 0 0 0 2px color("secondary-darker");
+      color: color("secondary-darker");
+    }
   }
 
   &--secondary {
     background-color: white;
-    box-shadow: inset 0 0 0 2px $accent-primary;
-    color: $accent-primary !important;
-  }
+    box-shadow: inset 0 0 0 2px color("secondary");
+    color: color("secondary");
 
-  &--secondary:hover {
-    background-color: white !important;
-    box-shadow: inset 0 0 0 2px $accent-dark;
-    color: $accent-dark !important;
-  }
+    &:hover {
+      background-color: white;
+      box-shadow: inset 0 0 0 2px color("secondary-dark");
+      color: color("secondary-dark");
+    }
 
-  &--secondary:active {
-    background-color: white !important;
-    box-shadow: inset 0 0 0 2px $accent-darker;
-    color: $accent-darker !important;
-  }
-
-  &:disabled,
-  &:disabled:hover,
-  &:disabled:active {
-    box-shadow: none;
-    cursor: not-allowed;
-    opacity: 1;
-    background-color: color("disabled-light") !important;
+    &:active {
+      background-color: white;
+      box-shadow: inset 0 0 0 2px color("secondary-darker");
+      color: color("secondary-darker");
+    }
   }
 
   &--destructive {
     box-shadow: none;
     color: white;
-    background-color: $destructive-primary !important;
-  }
-  &--destructive:hover {
-    box-shadow: none;
-    color: white;
-    background-color: $destructive-dark !important;
-  }
-  &--destructive:active {
-    box-shadow: none;
-    color: white;
-    background-color: $destructive-darker !important;
+    background-color: $destructive-primary;
+
+    &:hover {
+      box-shadow: none;
+      color: white;
+      background-color: $destructive-dark;
+    }
+
+    &:active {
+      box-shadow: none;
+      color: white;
+      background-color: $destructive-darker;
+    }
   }
 }
 
@@ -113,22 +126,22 @@ h4 {
 a,
 a:visited {
   box-shadow: none;
-  color: $brand-primary;
-  background-color: transparent !important;
+  color: color("primary");
+  background-color: transparent;
 }
 
 .usa-button--unstyled:hover,
 a:hover {
   box-shadow: none;
-  color: $brand-dark;
-  background-color: transparent !important;
+  color: color("primary-dark");
+  background-color: transparent;
 }
 
 .usa-button--unstyled:active,
 a:active {
   box-shadow: none;
-  color: $brand-darker;
-  background-color: transparent !important;
+  color: color("primary-darker");
+  background-color: transparent;
 }
 
 .usa-alert--success {
@@ -158,7 +171,7 @@ a:active {
 .usa-step-indicator__segment:before {
   box-shadow:
     0 0 0 0.25rem white,
-    0 0 0 0 white !important;
+    0 0 0 0 white;
 }
 
 .usa-step-indicator__segment-label,
@@ -167,16 +180,21 @@ a:active {
 }
 
 .usa-step-indicator__segment--current .usa-step-indicator__segment-label {
-  color: $brand-primary;
+  color: color("primary");
 }
 
 .usa-step-indicator__segment--current::before,
 .usa-step-indicator__segment--current::after {
-  background-color: $brand-primary;
-  color: $brand-primary;
+  background-color: color("primary");
+  color: color("primary");
   box-shadow:
     0 0 0 0.25rem white,
-    0 0 0 0 white !important;
+    0 0 0 0 white;
+}
+
+.usa-accordion {
+  border-radius: 4px;
+  padding: 0px;
 }
 
 .usa-accordion__button,
@@ -187,21 +205,23 @@ a:active {
 
 .usa-modal__close {
   background-color: white;
+  box-shadow: none;
 
   &:active,
   &:hover {
     background-color: white;
+    box-shadow: none;
   }
 }
 
 .usa-checkbox__input:checked + [class*="__label"]::before {
-  background-color: $accent-primary !important;
-  box-shadow: none !important;
+  background-color: color("secondary");
+  box-shadow: none;
 }
 .usa-radio__input:checked + [class*="__label"]::before {
-  background-color: $accent-primary !important;
+  background-color: color("secondary");
   box-shadow:
-    0 0 0 2px $accent-primary,
+    0 0 0 2px color("secondary"),
     inset 0 0 0 2px #fff;
 }
 
@@ -214,9 +234,8 @@ a:active {
   position: relative;
 }
 
-.usa-accordion {
-  border-radius: 4px;
-  padding: 0px;
+.usa-pagination {
+  background-color: transparent;
 }
 
 .usa-step-indicator__segment-label {
@@ -227,11 +246,19 @@ a:active {
   font-weight: bold;
 }
 
-ul.usa-sidenav > li.usa-sidenav__item > ul.usa-sidenav__sublist > li.usa-sidenav__item > a {
+ul.usa-sidenav
+  > li.usa-sidenav__item
+  > ul.usa-sidenav__sublist
+  > li.usa-sidenav__item
+  > a {
   font-weight: bold;
 }
 
-ul.usa-sidenav > li.usa-sidenav__item > ul.usa-sidenav__sublist > li.usa-sidenav__item > a.usa-current {
+ul.usa-sidenav
+  > li.usa-sidenav__item
+  > ul.usa-sidenav__sublist
+  > li.usa-sidenav__item
+  > a.usa-current {
   &::after {
     background-color: rgb(0, 94, 162);
     content: "";
@@ -246,7 +273,7 @@ ul.usa-sidenav > li.usa-sidenav__item > ul.usa-sidenav__sublist > li.usa-sidenav
 }
 
 .usa-step-indicator__current-step {
-  background-color: $brand-primary;
+  background-color: color("primary");
   margin-right: 0.5rem;
   padding: 0;
   height: 2.75rem;
@@ -254,7 +281,7 @@ ul.usa-sidenav > li.usa-sidenav__item > ul.usa-sidenav__sublist > li.usa-sidenav
 }
 
 .usa-step-indicator__total-steps {
-  color: $brand-primary;
+  color: color("primary");
 }
 
 .usa-step-indicator__total-steps,
@@ -262,45 +289,11 @@ ul.usa-sidenav > li.usa-sidenav__item > ul.usa-sidenav__sublist > li.usa-sidenav
   font-size: 2rem;
 }
 
-.usa-pagination .usa-current {
-  background-color: white;
-  border-radius: 0.25rem;
-  border: 1px solid $border-dark !important;
-  color: $accent-dark !important;
-  font-size: 1rem;
-  font-weight: 700;
-  line-height: 140%;
-  margin: 0;
-  text-decoration: underline;
-}
-
-.usa-pagination__button:hover,
-.usa-pagination__button:focus,
-.usa-pagination__button:active,
-.usa-pagination__link:hover,
-.usa-pagination__link:focus,
-.usa-pagination__link:active {
-  color: $accent-darker !important;
-}
-.usa-pagination__button:hover,
-.usa-pagination__button:focus,
-.usa-pagination__button:active {
-  border: 1px solid $border !important;
-  background-color: $hover-neutral !important;
-}
-
-.usa-pagination__button,
-.usa-pagination__link {
-  color: $accent-primary;
-  font-size: 1rem;
-  font-weight: 700;
-  line-height: 140%;
-  margin: 0;
-  text-decoration: none;
-}
-
-.usa-pagination__overflow {
-  align-self: center;
+.usa-step-indicator__segment--current:before,
+.usa-step-indicator__segment--complete:before {
+  box-shadow:
+    inset 0 0 0 0 color("primary-darker"),
+    0 0 0 0.25rem white;
 }
 
 .usa-alert__heading {
@@ -339,13 +332,6 @@ ul.usa-sidenav > li.usa-sidenav__item > ul.usa-sidenav__sublist > li.usa-sidenav
     font-weight: bold;
     line-height: 1.2;
   }
-}
-
-.usa-step-indicator__segment--current:before,
-.usa-step-indicator__segment--complete:before {
-  box-shadow:
-    inset 0 0 0 0 $brand-darker,
-    0 0 0 0.25rem white !important;
 }
 
 .usa-alert__text {

--- a/sass/design_system.scss
+++ b/sass/design_system.scss
@@ -39,7 +39,7 @@ h2,
   @include u-font("sans", 11);
 }
 h3,
-.usa-prose h3 {
+.usa-prose > h3 {
   @include u-font("sans", 8);
 }
 h4,

--- a/sass/design_system.scss
+++ b/sass/design_system.scss
@@ -356,7 +356,6 @@ ul.usa-sidenav
   > li.usa-sidenav__item
   > a.usa-current {
   &::after {
-    background-color: rgb(0, 94, 162);
     content: "";
     display: block;
     position: absolute;

--- a/sass/design_system.scss
+++ b/sass/design_system.scss
@@ -1,4 +1,4 @@
-@use "variables" as *;
+@use "_variables" as *;
 @use "uswds-core" as *;
 @use "uswds-theme" as *;
 
@@ -168,6 +168,48 @@ a:active {
   }
 }
 
+.usa-alert__heading {
+  &.h1 {
+    font-size: 2.125rem;
+    font-weight: bold;
+    line-height: 1.5;
+  }
+
+  &.h2 {
+    font-size: 1.875rem;
+    font-weight: bold;
+    line-height: 1.5;
+  }
+
+  &.h3 {
+    font-size: 1.5rem;
+    font-weight: bold;
+    line-height: 1.4;
+  }
+
+  &.h4 {
+    font-size: 1.25rem;
+    font-weight: bold;
+    line-height: 1.3;
+  }
+
+  &.h5 {
+    font-size: 1.125rem;
+    font-weight: bold;
+    line-height: 1.2;
+  }
+
+  &.h6 {
+    font-size: 1rem;
+    font-weight: bold;
+    line-height: 1.2;
+  }
+}
+
+.usa-alert__text {
+  font-size: 0.875rem;
+}
+
 .usa-step-indicator__segment:before {
   box-shadow:
     0 0 0 0.25rem white,
@@ -183,13 +225,79 @@ a:active {
   color: color("primary");
 }
 
+.usa-step-indicator__segment-label {
+  padding-right: 0;
+}
+
 .usa-step-indicator__segment--current::before,
 .usa-step-indicator__segment--current::after {
   background-color: color("primary");
   color: color("primary");
   box-shadow:
     0 0 0 0.25rem white,
-    0 0 0 0 white;
+    0 0 0 0 color("primary-darker");
+}
+
+.usa-step-indicator__current-step {
+  background-color: color("primary");
+  margin-right: 0.5rem;
+  padding: 0;
+  height: 2.75rem;
+  width: 2.75rem;
+}
+
+.usa-step-indicator__total-steps {
+  color: color("primary");
+}
+
+.usa-step-indicator__total-steps,
+.usa-step-indicator__current-step {
+  font-size: 2rem;
+}
+
+.usa-pagination .usa-current {
+  background-color: white;
+  border-radius: 0.25rem;
+  border: 1px solid $border-dark;
+  color: $accent-dark;
+  font-size: 1rem;
+  font-weight: 700;
+  line-height: 140%;
+  margin: 0;
+  text-decoration: underline;
+}
+
+.usa-pagination__button:hover,
+.usa-pagination__button:focus,
+.usa-pagination__button:active,
+.usa-pagination__link:hover,
+.usa-pagination__link:focus,
+.usa-pagination__link:active {
+  color: $accent-darker;
+}
+.usa-pagination__button:hover,
+.usa-pagination__button:focus,
+.usa-pagination__button:active {
+  border: 1px solid $border;
+  background-color: $hover-neutral;
+}
+
+.usa-pagination__button,
+.usa-pagination__link {
+  color: $accent-primary;
+  font-size: 1rem;
+  font-weight: 700;
+  line-height: 140%;
+  margin: 0;
+  text-decoration: none;
+}
+
+.usa-pagination__overflow {
+  align-self: center;
+}
+
+.usa-pagination {
+  background-color: transparent;
 }
 
 .usa-accordion {
@@ -234,18 +342,6 @@ a:active {
   position: relative;
 }
 
-.usa-pagination {
-  background-color: transparent;
-}
-
-.usa-step-indicator__segment-label {
-  padding-right: 0;
-}
-
-.usa-sidenav__item a:not(.usa-sidenav__sublist a) {
-  font-weight: bold;
-}
-
 ul.usa-sidenav
   > li.usa-sidenav__item
   > ul.usa-sidenav__sublist
@@ -272,68 +368,6 @@ ul.usa-sidenav
   }
 }
 
-.usa-step-indicator__current-step {
-  background-color: color("primary");
-  margin-right: 0.5rem;
-  padding: 0;
-  height: 2.75rem;
-  width: 2.75rem;
-}
-
-.usa-step-indicator__total-steps {
-  color: color("primary");
-}
-
-.usa-step-indicator__total-steps,
-.usa-step-indicator__current-step {
-  font-size: 2rem;
-}
-
-.usa-step-indicator__segment--current:before,
-.usa-step-indicator__segment--complete:before {
-  box-shadow:
-    inset 0 0 0 0 color("primary-darker"),
-    0 0 0 0.25rem white;
-}
-
-.usa-alert__heading {
-  &.h1 {
-    font-size: 2.125rem;
-    font-weight: bold;
-    line-height: 1.5;
-  }
-
-  &.h2 {
-    font-size: 1.875rem;
-    font-weight: bold;
-    line-height: 1.5;
-  }
-
-  &.h3 {
-    font-size: 1.5rem;
-    font-weight: bold;
-    line-height: 1.4;
-  }
-
-  &.h4 {
-    font-size: 1.25rem;
-    font-weight: bold;
-    line-height: 1.3;
-  }
-
-  &.h5 {
-    font-size: 1.125rem;
-    font-weight: bold;
-    line-height: 1.2;
-  }
-
-  &.h6 {
-    font-size: 1rem;
-    font-weight: bold;
-    line-height: 1.2;
-  }
-}
-
-.usa-alert__text {
-  font-size: 0.875rem;
+.usa-sidenav__item a:not(.usa-sidenav__sublist a) {
+  font-weight: bold;
 }


### PR DESCRIPTION
Some fixes and some kinda-opinionated changes from implementing this over at the ecr viewer

fixes:
* pagination and outline button hover/active states were wonky
* background color to match design system (didn't touch the darker ones since I'm not sure what they're used for in practice)
* change `header, footer` rule to `.usa-header, .usa-footer` for consistency (and that's what we had already customized)
* add light/lighter for the purples (this is a bit off script as the actual color scheme looks unusably awful at the light tones)
* extend header styles into `.usa-prose`

opinionated changes:
* re-org style rules so they are consolidated by thing they are customizing
* set the primary theme color to `$brand-<blah>` and secondary to `$accent-blah` and remove the variables to instead rely on the `color` utility function (this is also a bit of a fix as it caused more uswds components to "just work")